### PR TITLE
Add flompt visual prompt builder to tools list

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,7 @@ Prompt engineering is the craft of designing effective prompts to instruct and g
 - **[PromptLayer](https://www.promptlayer.com/)** – Prompt management and version control for LLM prompts.
 - **[Promptfoo](https://promptfoo.dev/)** – Tool for testing, evaluating, and benchmarking prompts.
 - **[Chainlit](https://www.chainlit.io/)** – Open-source framework for developing LLM-powered apps with prompt visibility.
+- **[flompt](https://github.com/Nyrok/flompt)** – Visual prompt builder that decomposes prompts into 12 semantic blocks and compiles them into Claude-optimized XML. Available as a web app, browser extension (Chrome/Firefox), and MCP server.
 
 ## Research & Papers
 


### PR DESCRIPTION
Adds [flompt](https://github.com/Nyrok/flompt) to the Prompt Engineering Tools section.

**What is flompt?**
flompt is a free, open-source visual prompt builder that:
- Decomposes any raw prompt into 12 semantic blocks (role, context, objective, constraints, examples, chain of thought, output format, etc.)
- Provides a visual canvas (React Flow) to drag, connect, and edit blocks
- Compiles blocks into Claude-optimized XML following Anthropic's best practices

Available as:
- Web app: https://flompt.dev
- Browser extension for ChatGPT, Claude, Gemini (Chrome + Firefox)
- MCP server: `claude mcp add flompt https://flompt.dev/mcp/`

No account needed, no API key, completely free and open-source.