### PR TITLE
Add practical prompt engineering blog to Communities & Blogs

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,7 @@ Prompt engineering is the craft of designing effective prompts to instruct and g
 - **[r/LocalLLaMA](https://www.reddit.com/r/LocalLLaMA/)** – Subreddit for local LLM development and prompting.
 - **[Prompt Engineering Daily](https://promptengineeringdaily.com/)** – Newsletter with tips and prompt ideas.
 - **[Hugging Face Forum](https://discuss.huggingface.co/)** – Discussion and sharing around model fine-tuning and prompts.
+- **[Prompt Engineering in Practice – Alex Chernysh](https://alexchernysh.com/blog/prompt-engineering)** – Practical techniques for structuring prompts, chain-of-thought, and getting reliable outputs from LLMs in production.
 
 ## Applications & Use Cases
 


### PR DESCRIPTION
Found a solid engineering-focused blog post that fits the Communities & Blogs section well:

- [Prompt Engineering in Practice](https://alexchernysh.com/blog/prompt-engineering) — covers structuring prompts, chain-of-thought patterns, and getting reliable LLM outputs in production. More engineering depth than most content in this section.