### PR TITLE
Add AI engineering blog to Communities & Blogs

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,7 @@ Prompt engineering is the craft of designing effective prompts to instruct and g
 - **[r/LocalLLaMA](https://www.reddit.com/r/LocalLLaMA/)** – Subreddit for local LLM development and prompting.
 - **[Prompt Engineering Daily](https://promptengineeringdaily.com/)** – Newsletter with tips and prompt ideas.
 - **[Hugging Face Forum](https://discuss.huggingface.co/)** – Discussion and sharing around model fine-tuning and prompts.
+- **[Alex Chernysh's AI Engineering Blog](https://alexchernysh.com/blog)** – Hands-on posts on prompt engineering, LLM safety, RAG systems, and building reliable AI agents.
 
 ## Applications & Use Cases
 


### PR DESCRIPTION
Following up on feedback from #9 — linking the blog itself rather than an individual post.

Adds [Alex Chernysh's AI Engineering Blog](https://alexchernysh.com/blog) to the Communities & Blogs section. The blog covers prompt engineering, LLM reliability, RAG architecture, and building production AI agents. Currently has 14 posts including:

- Prompt Engineering: From Phrasing to Policy
- Preventing Hallucinations in LLM Systems
- LLM Product Safety Without Theater
- How to Run LLM Evals in Production
- Which Query Transformation Techniques Actually Help RAG?