### PR TITLE
Add AceTagGen — Suno AI prompt builder

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,7 @@ Prompt engineering is the craft of designing effective prompts to instruct and g
 
 ## Prompt Engineering Tools
 
+- **[AceTagGen](https://acetaggen.com)** – Prompt builder specifically for Suno AI music generation. 12-step structured questionnaire, 3,000+ community-verified tags, quality-score validator. Open-source scorer on npm ([suno-prompt-scorer](https://www.npmjs.com/package/suno-prompt-scorer), MIT).
 - **[LangChain](https://www.langchain.com/)** – Framework for developing applications using LLMs with advanced prompt orchestration.
 - **[PromptLayer](https://www.promptlayer.com/)** – Prompt management and version control for LLM prompts.
 - **[Promptfoo](https://promptfoo.dev/)** – Tool for testing, evaluating, and benchmarking prompts.


### PR DESCRIPTION
Adds [AceTagGen](https://acetaggen.com) to the Prompt Engineering Tools section.

AceTagGen is a specialized prompt-building toolkit for Suno AI music generation. It uses a 12-step structured questionnaire (mood, genre, instruments, SFX, production style, vocals) to produce Suno-ready prompts that respect the 200-character Style field limit. Includes 3,000+ community-verified tags tested against Suno v4/v4.5/v5, a quality-score validator, and an AI Chat mode (Premium).

**Why it fits:** Prompt engineering for music AI is under-represented in your list — most entries are text-LLM focused. AceTagGen is the first prompt-engineering tool specifically for a music generation model.

Alphabetical position preserved (A before LangChain).

**Additional context:**
- Open-source scoring algorithm on npm: https://www.npmjs.com/package/suno-prompt-scorer (MIT)
- HuggingFace Space demo: https://huggingface.co/spaces/shaizadok/suno-prompt-scorer
- GitHub: https://github.com/shaizadok92/suno-prompt-scorer

**Disclosure:** I'm the sole developer of AceTagGen.