### PR TITLE
Add promptlint-mcp (static linter for AI prompts)

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,7 @@ Prompt engineering is the craft of designing effective prompts to instruct and g
 - **[Promptfoo](https://promptfoo.dev/)** – Tool for testing, evaluating, and benchmarking prompts.
 - **[Chainlit](https://www.chainlit.io/)** – Open-source framework for developing LLM-powered apps with prompt visibility.
 - **[flompt](https://github.com/Nyrok/flompt)** – Open source visual prompt builder that decomposes prompts into semantic blocks and compiles them into structured formats.
+- **[promptlint-mcp](https://github.com/sean-sunagaku/promptlint-mcp)** – Static linter for AI prompts. Catches contradictions, redundancy, ambiguity, long examples, and politeness fluff. CLI + MCP server. Zero network, MIT.
 
 ## Research & Papers
 


### PR DESCRIPTION
Adds [promptlint-mcp](https://github.com/sean-sunagaku/promptlint-mcp) under **Prompt Engineering Tools**.

It detects contradictions, redundancy, ambiguous pronouns, oversized examples, and politeness fluff in system prompts and agent instructions. Returns a score + issue list + sentence-aware trimmed text. Zero network, zero LLM calls. CLI + MCP server. MIT.

Tools exposed:
- `lint_prompt(text)` - score, issues, trimmed text, token savings
- `trim_prompt(text)` - mechanically trimmed prompt (preserves quoted / backticked / fenced content)

Tested with Claude Code via `claude mcp add`.