### PR TITLE
Add Ejentum to Prompt Engineering Tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,7 @@ Prompt engineering is the craft of designing effective prompts to instruct and g
 - **[Promptfoo](https://promptfoo.dev/)** – Tool for testing, evaluating, and benchmarking prompts.
 - **[Chainlit](https://www.chainlit.io/)** – Open-source framework for developing LLM-powered apps with prompt visibility.
 - **[flompt](https://github.com/Nyrok/flompt)** – Open source visual prompt builder that decomposes prompts into semantic blocks and compiles them into structured formats.
+- **[Ejentum](https://ejentum.com)** – Reasoning harness. Four agentic tools (reasoning, code, anti-deception, memory) the agent calls during its loop; each returns a structured cognitive scaffold (named failure pattern, executable procedure, suppression vectors, falsification test) the model reads internally. Ships as MCP server and twelve native framework integrations on PyPI/npm.
 
 ## Research & Papers
 


### PR DESCRIPTION
Adds **Ejentum** under `## Prompt Engineering Tools`.

Ejentum is a pre-generation reasoning harness. Four agent-callable tools (`harness_reasoning`, `harness_code`, `harness_anti_deception`, `harness_memory`) return structured cognitive scaffolds (named failure pattern, executable procedure, suppression vectors, falsification test) the model reads internally before producing its user-facing answer. The scaffolds are essentially structured prompt fragments fetched on demand via a tool call, so the prompt-engineering surface is what callers interact with.

- Homepage: https://ejentum.com
- Source: https://github.com/ejentum/ejentum-mcp
- Twelve native framework integrations live on PyPI/npm
- Paper: ["Under Pressure" (Zenodo)](https://doi.org/10.5281/zenodo.19392715)
- License: MIT

Format follows existing entries (bullet, bold link, descriptive sentence).