### PR TITLE
Add Prompt Engineering Techniques to Courses & Tutorials

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,7 @@ Prompt engineering is the craft of designing effective prompts to instruct and g
 - **[Learn Prompting](https://learnprompting.org/)** – Open-source and beginner-friendly prompt engineering course.
 - **[LangChain Prompt Templates](https://docs.langchain.com/docs/components/prompts/prompt-templates/)** – How to design reusable prompt templates in LangChain.
 - **[FreeCodeCamp – Prompt Engineering Tutorial](https://www.youtube.com/watch?v=qw1uPj9qy3g)** – Hands-on tutorial with examples.
+- **[Prompt Engineering Techniques](https://github.com/NirDiamant/Prompt_Engineering)** – 22 prompt engineering techniques with hands-on Jupyter Notebook tutorials, from fundamentals to advanced LLM strategies.
 
 ## Prompt Libraries
 


### PR DESCRIPTION
This adds the **Prompt Engineering Techniques** repo to the *Courses & Tutorials* section.

- Link: https://github.com/NirDiamant/Prompt_Engineering
- 22 prompt engineering techniques, each with a runnable, hands-on Jupyter Notebook tutorial, spanning fundamentals to advanced LLM strategies (7k+ stars, actively maintained).

It fits the section as a hands-on, tutorial-driven learning resource and follows the existing entry format. Disclosure: I am the author of the repository.