### PR TITLE
Add CreatorSkills to Prompt Libraries

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,7 @@ Prompt engineering is the craft of designing effective prompts to instruct and g
 - **[PromptBase](https://promptbase.com/)** – Marketplace to buy and sell AI prompts.
 - **[FlowGPT](https://flowgpt.com/)** – Community-curated prompt sharing and discovery platform.
 - **[PromptHero](https://prompthero.com/)** – Prompt library focused on generative art and image models.
+- **[CreatorSkills](https://creatorskills.co)** – Marketplace of 30+ downloadable AI skills for content creators — YouTube scripting, sponsorship analysis, content repurposing, and audience growth. Skills use the open SKILL.md format and work with Claude, ChatGPT, and 20+ AI platforms.
 
 ## Prompt Engineering Tools
 


### PR DESCRIPTION
## Summary

Adds [CreatorSkills](https://creatorskills.co) to the **Prompt Libraries** section alongside PromptBase, FlowGPT, and PromptHero.

CreatorSkills is a curated marketplace of 30+ downloadable AI skills specifically designed for content creators — covering YouTube scripting, sponsorship analysis, content repurposing, and audience growth. Unlike generic prompt marketplaces, skills are distributed using the open **SKILL.md format** and integrate directly with Claude, ChatGPT, and 20+ other AI platforms.

It's a natural addition next to PromptBase as a structured skills marketplace tailored for a specific professional audience (content creators).