### PR TITLE
feat: add CreatorSkills to Prompt Libraries section

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,7 @@ Prompt engineering is the craft of designing effective prompts to instruct and g
 - **[PromptBase](https://promptbase.com/)** – Marketplace to buy and sell AI prompts.
 - **[FlowGPT](https://flowgpt.com/)** – Community-curated prompt sharing and discovery platform.
 - **[PromptHero](https://prompthero.com/)** – Prompt library focused on generative art and image models.
+- **[CreatorSkills](https://creatorskills.co)** – Marketplace of 30+ downloadable AI skills for content creators — YouTube scripting, sponsorship analysis, content repurposing, and audience growth. Skills use the open SKILL.md format and work with Claude, ChatGPT, and 20+ AI platforms.
 
 ## Prompt Engineering Tools
 

--- a/README.md
+++ b/README.md
@@ -39,6 +39,7 @@ Prompt engineering is the craft of designing effective prompts to instruct and g
 
 - **[Awesome ChatGPT Prompts](https://github.com/f/awesome-chatgpt-prompts)** – A collection of useful and creative prompts for ChatGPT.
 - **[PromptBase](https://promptbase.com/)** – Marketplace to buy and sell AI prompts.
+- **[CreatorSkills](https://creatorskills.co/)** – Marketplace of 30+ downloadable AI skills for content creators, covering YouTube scripting, sponsorship analysis, content repurposing, and audience growth.
 - **[FlowGPT](https://flowgpt.com/)** – Community-curated prompt sharing and discovery platform.
 - **[PromptHero](https://prompthero.com/)** – Prompt library focused on generative art and image models.
 - **[CreatorSkills](https://creatorskills.co)** – Marketplace of 30+ downloadable AI skills for content creators — YouTube scripting, sponsorship analysis, content repurposing, and audience growth. Skills use the open SKILL.md format and work with Claude, ChatGPT, and 20+ AI platforms.

--- a/README.md
+++ b/README.md
@@ -39,10 +39,9 @@ Prompt engineering is the craft of designing effective prompts to instruct and g
 
 - **[Awesome ChatGPT Prompts](https://github.com/f/awesome-chatgpt-prompts)** – A collection of useful and creative prompts for ChatGPT.
 - **[PromptBase](https://promptbase.com/)** – Marketplace to buy and sell AI prompts.
-- **[CreatorSkills](https://creatorskills.co/)** – Marketplace of 30+ downloadable AI skills for content creators, covering YouTube scripting, sponsorship analysis, content repurposing, and audience growth.
+- **[CreatorSkills](https://creatorskills.co)** – Marketplace of 30+ downloadable AI skills for content creators — YouTube scripting, sponsorship analysis, content repurposing, and audience growth. Skills use the open SKILL.md format and work with Claude, ChatGPT, and 20+ AI platforms.
 - **[FlowGPT](https://flowgpt.com/)** – Community-curated prompt sharing and discovery platform.
 - **[PromptHero](https://prompthero.com/)** – Prompt library focused on generative art and image models.
-- **[CreatorSkills](https://creatorskills.co)** – Marketplace of 30+ downloadable AI skills for content creators — YouTube scripting, sponsorship analysis, content repurposing, and audience growth. Skills use the open SKILL.md format and work with Claude, ChatGPT, and 20+ AI platforms.
 
 ## Prompt Engineering Tools
 


### PR DESCRIPTION
## Summary

Adds [CreatorSkills](https://creatorskills.co) to the **Prompt Libraries** section alongside PromptBase, FlowGPT, and PromptHero.

CreatorSkills is a marketplace of 30+ downloadable AI skills (structured prompts/instructions) for content creators — covering YouTube scripting, sponsorship analysis, and audience growth. Unlike image-focused prompt marketplaces, it specializes in content workflow skills for Claude and ChatGPT.

## Entry Added

```
- **[CreatorSkills](https://creatorskills.co)** – Marketplace of 30+ downloadable AI skills for content creators covering YouTube scripting, sponsorship analysis, and audience growth. Works with Claude and ChatGPT.
```